### PR TITLE
Considering empty string as a violation of required validator.

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -354,7 +354,7 @@ var Validator = (function() {
 				{
 					var required = fieldValidations[0].options === true;
 
-					if(required && typeof value === 'undefined')
+					if(required && (typeof value === 'undefined' || value == ''))
 					{
 						var validationInfo = fieldValidations[0];
 						var promise = Q({


### PR DESCRIPTION
I was trying out this module and discovered that when I have a form with empty text fields that have the required validator set to true they were not being flagged as an error.  This change causes the validator to give an error in this case.
